### PR TITLE
Make storeAccessToken public

### DIFF
--- a/Sources/Instagram.swift
+++ b/Sources/Instagram.swift
@@ -122,7 +122,7 @@ public class Instagram {
 
     // MARK: - Access Token
 
-    private func storeAccessToken(_ accessToken: String) -> Bool {
+    public func storeAccessToken(_ accessToken: String) -> Bool {
         return keychain.set(accessToken, forKey: Keychain.accessTokenKey)
     }
 


### PR DESCRIPTION
Instagram's recommended way of authenticating users is via server-side. Through server-side auth, a code is sent to the server and the server then returns an access token. By making this method public, we can save the access token that we receive in return.

## Checklist

- [x] I've tested my changes.
- [x] I've updated the [documentation](https://andergoig.github.io/SwiftInstagram), if necessary.
- [x] I have read the [contibution guidelines](CONTRIBUTING.md).

## Proposed Changes

  - Make saveAccessToken public to allow server-side authentication. 
