### PR TITLE
Fix layout issue for iPhoneX

### DIFF
--- a/Sources/Views/InstagramLoginViewController.swift
+++ b/Sources/Views/InstagramLoginViewController.swift
@@ -87,12 +87,20 @@ class InstagramLoginViewController: UIViewController {
         webConfiguration.websiteDataStore = .nonPersistent()
 
         let webView = WKWebView(frame: view.frame, configuration: webConfiguration)
-        webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         webView.navigationDelegate = self
 
         webViewObservation = webView.observe(\.estimatedProgress, changeHandler: progressViewChangeHandler)
 
         view.addSubview(webView)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        var topAnchor = view.topAnchor
+        if #available(iOS 11.0, *) {
+          topAnchor = view.safeAreaLayoutGuide.topAnchor
+        }
+        webView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        webView.heightAnchor.constraint(equalTo: view.heightAnchor).isActive = true
+        webView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        webView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
 
         return webView
     }


### PR DESCRIPTION
## Checklist

- [X ] I've tested my changes.
- [ X] I've updated the [documentation](https://andergoig.github.io/SwiftInstagram), if necessary.
- [ X] I have read the [contibution guidelines](CONTRIBUTING.md).

## Proposed Changes

  
  The webView is showing behind the navigation bar for some iPhones, I changed it to AutoLayout in order to use `safeAreaLayoutGuide`, now the webView is not being overlapped by the nav bar in different screen sizes.


  